### PR TITLE
Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
     - linux
 julia:
-    - 0.5
+    - 0.6
 notifications:
     email: false
 sudo: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 JuMP 0.16.2 0.17
 MathProgBase 0.6.4 0.7

--- a/src/JuMPeR.jl
+++ b/src/JuMPeR.jl
@@ -34,7 +34,7 @@ export RobustModel, @uncertain, @adaptive,
 All uncertainty sets implement the interface defined by AbstractUncertaintySet.
 Parent type is JuMP.AbstractModel, to enable JuMP's `@constraint`, etc.
 """
-abstract AbstractUncertaintySet <: JuMP.AbstractModel
+abstract type AbstractUncertaintySet <: JuMP.AbstractModel end
 
 
 """
@@ -194,7 +194,7 @@ include("adaptive.jl")
 
 `∑ⱼ (∑ᵢ aᵢⱼ uᵢ) xⱼ`  --  affine expression of unc. parameters and variables.
 """
-typealias UncVarExpr JuMP.GenericAffExpr{UncExpr,JuMPeRVar}
+const UncVarExpr = JuMP.GenericAffExpr{UncExpr,JuMPeRVar}
 UncVarExpr() = zero(UncVarExpr)
 Base.convert(::Type{UncVarExpr}, c::Number) =
     UncVarExpr(JuMPeRVar[], UncExpr[], UncExpr(c))
@@ -215,7 +215,7 @@ end
 
 A constraint with uncertain parameters and variables (i.e., `UncVarExpr`).
 """
-typealias UncConstraint JuMP.GenericRangeConstraint{UncVarExpr}
+const UncConstraint = JuMP.GenericRangeConstraint{UncVarExpr}
 function JuMP.addconstraint(m::Model, c::UncConstraint; uncset=nothing)
     # Handle the odd special case where there are actually no variables in
     # the constraint - arises from use of macros

--- a/src/adaptive.jl
+++ b/src/adaptive.jl
@@ -50,7 +50,7 @@ getname(x::Adaptive) = get_robust(x.m).adp_names[x.id]
 
 Either a plain JuMP Variable, or a JuMPeR Adaptive variable.
 """
-typealias JuMPeRVar Union{Variable,Adaptive}
+const JuMPeRVar = Union{Variable,Adaptive}
 
 
 """
@@ -58,7 +58,7 @@ typealias JuMPeRVar Union{Variable,Adaptive}
 
 `∑ᵢ aᵢ vᵢ`  --  affine expression of JuMPeRVars and numbers.
 """
-typealias AdaptExpr JuMP.GenericAffExpr{Float64,JuMPeRVar}
+const AdaptExpr = JuMP.GenericAffExpr{Float64,JuMPeRVar}
 AdaptExpr() = zero(AdaptExpr)
 Base.convert(::Type{AdaptExpr}, c::Number) =
     AdaptExpr(JuMPeRVar[ ], Float64[ ], 0.0)
@@ -73,7 +73,7 @@ Base.convert(::Type{AdaptExpr}, aff::AffExpr) =
 
 A constraint with just JuMPeRVars and numbers (i.e., `AdaptExpr`).
 """
-typealias AdaptConstraint JuMP.GenericRangeConstraint{AdaptExpr}
+const AdaptConstraint = JuMP.GenericRangeConstraint{AdaptExpr}
 function JuMP.addconstraint(m::Model, c::AdaptConstraint)
     rm = get_robust(m)::RobustModelExt
     push!(rm.adapt_constraints, c)

--- a/src/print.jl
+++ b/src/print.jl
@@ -224,7 +224,7 @@ function cont_str(mode, j::Union{JuMPContainer{Uncertain},Array{Uncertain}},
         end
     end
     num_dims = length(data.indexsets)
-    idxvars = Array(String, num_dims)
+    idxvars = Array{String}(num_dims)
     dimidx = 1
     for i in 1:num_dims
         if data.indexexprs[i].idxvar == nothing
@@ -326,7 +326,7 @@ function aff_str(mode, a::UncExpr, show_constant=true)
     end
 
     elm = 1
-    term_str = Array(String, 2*length(a.vars))
+    term_str = Array{String}(2 * length(a.vars))
     # For each non-zero for this model
     for i in 1:indvec.nnz
         idx = indvec.nzidx[i]
@@ -380,7 +380,7 @@ function aff_str(mode, a::UncVarExpr, show_constant=true)
     rmext = get_robust(m)
 
     # Don't collect like terms
-    term_str = Array(String, length(a.vars))
+    term_str = Array{String}(length(a.vars))
     numTerms = 0
     first = true
     for i in 1:length(a.vars)
@@ -511,7 +511,7 @@ function aff_str(mode, a::AdaptExpr, show_constant=true)
     end
 
     elm = 1
-    term_str = Array(String, 2*length(a.vars))
+    term_str = Array{String}(2 * length(a.vars))
     # For each non-zero
     for i in 1:indvec_var.nnz
         idx = indvec_var.nzidx[i]

--- a/src/robustmacro.jl
+++ b/src/robustmacro.jl
@@ -290,6 +290,9 @@ macro adaptive(args...)
     end
 
     # separate out keyword arguments
+    println("================")
+    show_sexpr(extra)
+    println("================")
     kwargs = filter(ex->isexpr(ex,:kw), extra)
     extra = filter(ex->!isexpr(ex,:kw), extra)
 

--- a/src/uncertain.jl
+++ b/src/uncertain.jl
@@ -46,7 +46,7 @@ Base.isequal(u1::Uncertain, u2::Uncertain) = (u1.m === u2.m) && isequal(u1.id, u
 
 `∑ᵢ aᵢ uᵢ`  --  affine expression of uncertain parameters and numbers.
 """
-typealias UncExpr JuMP.GenericAffExpr{Float64,Uncertain}
+const UncExpr =JuMP.GenericAffExpr{Float64,Uncertain}
 Base.convert(::Type{UncExpr}, u::Uncertain) = UncExpr(Uncertain[u],Float64[1],0.0)
 Base.convert(::Type{UncExpr}, c::Number)    = UncExpr(Uncertain[ ],Float64[ ],  c)
 UncExpr() = zero(UncExpr)
@@ -59,7 +59,7 @@ UncExpr(c::Number,u::Uncertain) = UncExpr(Uncertain[u],Float64[c],0.0)
 
 A constraint with just uncertain parameters and numbers (i.e., `UncExpr`).
 """
-typealias UncSetConstraint JuMP.GenericRangeConstraint{UncExpr}
+const UncSetConstraint = JuMP.GenericRangeConstraint{UncExpr}
 function JuMP.addconstraint(m::Model, c::UncSetConstraint)
     # If m is a RobustModel, we add it to the default uncertainty set
     rmext = get_robust(m)::RobustModelExt
@@ -78,7 +78,7 @@ end
 
 A norm on uncertain parameters.
 """
-typealias UncSetNorm{Typ} GenericNorm{Typ,Float64,Uncertain}
+const UncSetNorm{Typ} = GenericNorm{Typ,Float64,Uncertain}
 JuMP._build_norm(Lp, terms::Vector{UncExpr}) = UncSetNorm{Lp}(terms)
 
 

--- a/src/uncsets_budget.jl
+++ b/src/uncsets_budget.jl
@@ -105,7 +105,7 @@ function get_worst_case_value(us::BudgetUncertaintySet, rm::Model, idx::Int)
     # We now scale the x values by the deviations, and take the absolute
     # values - if σᵢ xᵢ is negative, we want to set ξᵢ=μᵢ-σᵢ, and if it
     # is positive, the opposite.
-    scaled_vals = abs(unc_x_vals) .* us.σ
+    scaled_vals = abs.(unc_x_vals) .* us.σ
     # We don't need to sort the list, just the permutation vector
     # of indices as if we had sorted. We then take the top Γ indices.
     max_inds = sortperm(scaled_vals)[(end - us.Γ + 1):end]

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,3 @@
-BaseTestNext
 GLPKMathProgInterface
 GLPK 0.4 0.4.2
 ECOS

--- a/test/adp_inventory.jl
+++ b/test/adp_inventory.jl
@@ -14,7 +14,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 5e-3
 

--- a/test/adp_newsvendor.jl
+++ b/test/adp_newsvendor.jl
@@ -21,7 +21,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 lastuc(rm) = string(JuMPeR.get_robust(rm).unc_constraints[end])
 lastus(rm) = string(JuMPeR.get_robust(rm).default_uncset.linear_constraints[end])

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 import JuMP: REPLMode, IJuliaMode
 
 # To ensure the tests work on both Windows and Linux/OSX, we need

--- a/test/print.jl
+++ b/test/print.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 import JuMP: repl
 
 # Helper function to test IO methods work correctly

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 # Use JuMP's testing code to load available solvers
 # and provide vectors of solvers by capability

--- a/test/uncsets.jl
+++ b/test/uncsets.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 if !(:lp_solvers in names(Main))
     print_with_color(:magenta, "Loading solvers...\n")

--- a/test/uncsets_basic.jl
+++ b/test/uncsets_basic.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 

--- a/test/uncsets_basic_L1.jl
+++ b/test/uncsets_basic_L1.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 

--- a/test/uncsets_basic_L2.jl
+++ b/test/uncsets_basic_L2.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 

--- a/test/uncsets_basic_Linf.jl
+++ b/test/uncsets_basic_Linf.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 

--- a/test/uncsets_budget.jl
+++ b/test/uncsets_budget.jl
@@ -12,7 +12,7 @@
 #-----------------------------------------------------------------------
 
 using JuMP, JuMPeR
-using BaseTestNext
+using Base.Test
 
 const TOL = 1e-4
 


### PR DESCRIPTION
Make a few changes to the syntax so that JuMPeR is useable on Julia 0.6 without deprecation warnings. 

On my machine, not all tests pass. However, most of them are due to "wrong" prints (<= instead of ≤), and I could not find a solution for this. I am working on Windows 10 x64, with Julia 0.6.0 x64. 

Another test fails, but I do not worry a lot about it: it only concerns CPLEX (while Gurobi, CLP, GLPK, Ipopt, and ECOS have no problems). Here is the corresponding log: 

```
WARNING: CPLEX reported infeasible or unbounded. Set CPX_PARAM_REDUCE=1 to check
                        infeasibility or CPX_PARAM_REDUCE=2 to check unboundedness.
WARNING: Variable value not defined for x. Check that the model was properly solved.
Test 8 (unbounded LP): Error During Test
  Test threw an exception of type ErrorException
  Expression: solve(m, prefer_cuts=cuts, suppress_warnings=true) == :Unbounded
  Invalid coefficient NaN on variable u
  Stacktrace:
   [1] assert_isfinite(::JuMP.GenericAffExpr{Float64,JuMP.Variable}) at C:\Users\Thibaut\.julia\v0.6\JuMP\src\affexpr.jl:95
   [2] prepAffObjective(::JuMP.Model) at C:\Users\Thibaut\.julia\v0.6\JuMP\src\solvers.jl:549
   [3] #build#116(::Bool, ::Bool, ::JuMP.ProblemTraits, ::Function, ::JuMP.Model) at C:\Users\Thibaut\.julia\v0.6\JuMP\src\solvers.jl:376
   [4] (::JuMP.#kw##build)(::Array{Any,1}, ::JuMP.#build, ::JuMP.Model) at .\<missing>:0
   [5] #solve#111(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at C:\Users\Thibaut\.julia\v0.6\JuMP\src\solvers.jl:166
   [6] (::JuMP.#kw##solve)(::Array{Any,1}, ::JuMP.#solve, ::JuMP.Model) at .\<missing>:0
   [7] get_worst_case_value(::JuMPeR.BasicUncertaintySet, ::JuMP.Model, ::Int64) at C:\Users\Thibaut\.julia\v0.6\JuMPeR\src\uncsets_basic_cut.jl:107
   [8] generate_cut(::JuMPeR.BasicUncertaintySet, ::JuMP.Model, ::Array{Int64,1}) at C:\Users\Thibaut\.julia\v0.6\JuMPeR\src\uncsets_basic_cut.jl:147
   [9] _solve_robust(::JuMP.Model, ::Bool, ::Bool, ::Bool, ::Bool, ::Array{Any,1}) at C:\Users\Thibaut\.julia\v0.6\JuMPeR\src\solve.jl:186
   [10] (::JuMPeR.#kw##solve_robust)(::Array{Any,1}, ::JuMPeR.#solve_robust, ::JuMP.Model) at .\<missing>:0
   [11] #solve#111(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at C:\Users\Thibaut\.julia\v0.6\JuMP\src\solvers.jl:149
   [12] (::JuMP.#kw##solve)(::Array{Any,1}, ::JuMP.#solve, ::JuMP.Model) at .\<missing>:0
   [13] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:133 [inlined]
   [14] macro expansion at .\test.jl:860 [inlined]
   [15] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:127 [inlined]
   [16] macro expansion at .\test.jl:921 [inlined]
   [17] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:30 [inlined]
   [18] macro expansion at .\test.jl:860 [inlined]
   [19] anonymous at .\<missing>:?
Test 8 (unbounded LP): Test Failed
  Expression: solve(m, prefer_cuts=cuts, suppress_warnings=true) == :Unbounded
   Evaluated: InfeasibleOrUnbounded == Unbounded
Stacktrace:
 [1] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:133 [inlined]
 [2] macro expansion at .\test.jl:860 [inlined]
 [3] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:127 [inlined]
 [4] macro expansion at .\test.jl:921 [inlined]
 [5] macro expansion at C:\Users\Thibaut\.julia\v0.6\JuMPeR\test\uncsets_basic.jl:30 [inlined]
 [6] macro expansion at .\test.jl:860 [inlined]
 [7] anonymous at .\<missing>:?
```

I therefore think this is not too dangerous to merge. The main difference with the existing version is that this requires Julia 0.6.